### PR TITLE
Fix hostname persistence when ARP/DHCP data lacks names

### DIFF
--- a/src/dhcpFetcher.ts
+++ b/src/dhcpFetcher.ts
@@ -1,5 +1,5 @@
 import { Client } from "ssh2";
-import { AccessPointConfig } from "./types";
+import { AccessPointConfig, LeaseInfo } from "./types";
 import { EventEmitter } from "events";
 
 export class DHCPFetcher extends EventEmitter {
@@ -50,17 +50,20 @@ export class DHCPFetcher extends EventEmitter {
     });
   }
 
-  private parseLeases(leaseData: string): { [mac: string]: { hostname: string; ip: string } } {
+  private parseLeases(leaseData: string): { [mac: string]: LeaseInfo } {
     const lines = leaseData.split("\n");
-    const leaseMap: { [mac: string]: { hostname: string; ip: string } } = {};
+    const leaseMap: { [mac: string]: LeaseInfo } = {};
 
     lines.forEach((line) => {
       const parts = line.trim().split(/\s+/);
       if (parts.length >= 3) {
         const mac = parts[1].toLowerCase();
         const ip = parts[2];
-        const hostname = parts[3] || "Unknown";
-        leaseMap[mac] = { hostname, ip };
+        const hostname = parts[3];
+        leaseMap[mac] = { ip };
+        if (hostname) {
+          leaseMap[mac].hostname = hostname;
+        }
       }
     });
 

--- a/src/networkFetcher.ts
+++ b/src/networkFetcher.ts
@@ -1,5 +1,5 @@
 import { Client } from 'ssh2';
-import { AccessPointConfig } from './types';
+import { AccessPointConfig, LeaseInfo } from './types';
 import { EventEmitter } from 'events';
 import dns from 'dns';
 
@@ -48,9 +48,9 @@ export class NetworkFetcher extends EventEmitter {
     });
   }
 
-  private async parseARP(arpData: string): Promise<{ [mac: string]: { ip: string, hostname: string } }> {
+  private async parseARP(arpData: string): Promise<{ [mac: string]: LeaseInfo }> {
     const lines = arpData.split('\n').slice(1); // Skip header line
-    const result: { [mac: string]: { ip: string, hostname: string } } = {};
+    const result: { [mac: string]: LeaseInfo } = {};
 
     for (const line of lines) {
       const parts = line.trim().split(/\s+/);
@@ -60,10 +60,10 @@ export class NetworkFetcher extends EventEmitter {
 
         if (mac !== '00:00:00:00:00:00') {
           const hostname = await this.reverseLookup(ip);
-          result[mac] = {
-            ip,
-            hostname: hostname || ip // fallback to IP if no hostname
-          };
+          result[mac] = { ip };
+          if (hostname) {
+            result[mac].hostname = hostname;
+          }
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,11 @@ export interface Config {
   clients?: { [mac: string]: string }; // Optional map of MAC to names
 }
 
+export interface LeaseInfo {
+  ip: string;
+  hostname?: string;
+}
+
 export interface RoamingEvent {
   mac: string;
   apName: string;


### PR DESCRIPTION
## Summary
- preserve hostnames across DHCP/ARP updates
- store hostnames only when known and merge with existing ones

## Testing
- `npx tsx src/index.ts` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_686a2741ca7c832592a1644082fd899a