### PR TITLE
Improve FT log detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Phone                    aa:bb:cc:dd:ee:ff   AP2          No     12:25:10   AP1 
   ```
   FT authentication already completed - do not start 4-way handshake
   ```
+- The tracker extracts the client's MAC address from anywhere in the line.
 - If this message appears **before a client reassociation**, it is marked as a **Fast Transition**.
 
 ---

--- a/src/roamingTracker.ts
+++ b/src/roamingTracker.ts
@@ -116,11 +116,12 @@ export class RoamingTracker {
     const now = new Date();
 
     // FT Detection
-    const ftRegex = /FT authentication already completed - do not start 4-way handshake.*([\da-f:]{17})?/i;
-    const ftMatch = logLine.match(ftRegex);
-    if (ftMatch) {
-      const mac = ftMatch[1]?.toLowerCase();
-      if (mac) {
+    const ftMessageRegex = /FT authentication already completed - do not start 4-way handshake/i;
+    const macRegex = /([\da-f]{2}(?::[\da-f]{2}){5})/i;
+    if (ftMessageRegex.test(logLine)) {
+      const macMatch = logLine.match(macRegex);
+      if (macMatch) {
+        const mac = macMatch[1].toLowerCase();
         if (!this.clients.has(mac)) {
           this.clients.set(mac, { events: [], pendingFT: false });
         }


### PR DESCRIPTION
## Summary
- parse MAC addresses anywhere on lines containing the FT authentication message
- document MAC extraction behavior in README

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686a3061463c8325935293433795f731