### PR TITLE
Implement persistent connections and host mapping

### DIFF
--- a/backend/config_template.json
+++ b/backend/config_template.json
@@ -9,5 +9,7 @@
   ],
   "clients": {
     "ff:ff:ff:ff:ff:ff": "Laptop"
+  },
+  "hosts": {
   }
 }

--- a/backend/src/configLoader.ts
+++ b/backend/src/configLoader.ts
@@ -3,9 +3,13 @@ import path from "path";
 import { Config } from "./types";
 
 const dirname = path.dirname(new URL(import.meta.url).pathname);
+const configPath = path.resolve(dirname, "../config.json");
 
 export function loadConfig(): Config {
-  const configPath = path.resolve(dirname, "../config.json");
   const raw = fs.readFileSync(configPath, "utf-8");
   return JSON.parse(raw) as Config;
+}
+
+export function saveConfig(config: Config) {
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from "./configLoader";
+import { loadConfig, saveConfig } from "./configLoader";
 import { SSHLogWatcher } from "./sshLogWatcher";
 import { RoamingTracker } from "./roamingTracker";
 import { DHCPFetcher } from "./dhcpFetcher";
@@ -10,7 +10,14 @@ import path from "path";
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 const config = loadConfig();
-const tracker = new RoamingTracker(config.clients || {});
+const tracker = new RoamingTracker(
+  config.clients || {},
+  config.hosts || {},
+  (hosts) => {
+    config.hosts = hosts;
+    saveConfig(config);
+  }
+);
 
 // Start log watchers
 config.accessPoints.forEach((ap) => {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -8,6 +8,7 @@ export interface AccessPointConfig {
 export interface Config {
   accessPoints: AccessPointConfig[];
   clients?: { [mac: string]: string }; // Optional map of MAC to names
+  hosts?: { [ip: string]: string }; // Optional map of IP to hostnames
 }
 
 export interface LeaseInfo {


### PR DESCRIPTION
## Summary
- track IP-to-host mappings in config
- persist host map updates automatically
- keep SSH connections open for lease and ARP fetching

## Testing
- `npm --prefix backend install`
- `npm --prefix backend start` *(fails: ENOENT no such file or directory '/workspace/11r-monitor/backend/config.json')*

------
https://chatgpt.com/codex/tasks/task_e_686d0c2425788325829ef4390cfda770