### PR TITLE
Enable inline device name editing

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,10 +50,27 @@ config.accessPoints.forEach((ap) => {
 
 const app = express();
 app.use(cors());
+app.use(express.json());
 app.use(express.static(path.resolve(__dirname, "../../frontend")));
 
 app.get("/api/clients", (_req, res) => {
   res.json(tracker.getClientData());
+});
+
+app.post("/api/clients/:mac/name", (req, res) => {
+  const mac = req.params.mac.toLowerCase();
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    res.status(400).json({ error: "Missing name" });
+    return;
+  }
+  if (!config.clients) {
+    config.clients = {};
+  }
+  config.clients[mac] = name;
+  saveConfig(config);
+  tracker.setClientName(mac, name);
+  res.json({ success: true });
 });
 
 const PORT = process.env.PORT || 3000;

--- a/backend/src/roamingTracker.ts
+++ b/backend/src/roamingTracker.ts
@@ -198,4 +198,8 @@ export class RoamingTracker {
       this.saveHosts(this.hostMap);
     }
   }
+
+  setClientName(mac: string, name: string) {
+    this.macToName[mac.toLowerCase()] = name;
+  }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -70,7 +70,7 @@
       </thead>
       <tbody>
         <tr v-for="client in clients" :key="client.mac" :class="{old: client.diffSec > 7200}">
-          <td>{{ client.name }}</td>
+          <td @click="setName(client)">{{ client.name }}</td>
           <td>{{ client.ip }}</td>
           <td>{{ client.mac }}</td>
           <td>{{ client.currentAp }}</td>
@@ -127,10 +127,23 @@
           if (diffSec < 60) return `${diffSec}s ago`;
           if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
           return `${Math.floor(diffSec / 3600)}h ago`;
+        },
+        setName(client) {
+          const newName = prompt('Enter name', client.name);
+          if (newName && newName !== client.name) {
+            fetch(`/api/clients/${client.mac}/name`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name: newName })
+            })
+              .then(() => {
+                client.name = newName;
+              })
+              .catch(err => console.error(err));
+          }
         }
       }
     }).mount('#app');
   </script>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- allow editing client name via UI
- persist custom names in `config.json`
- expose a backend route to update client name

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e5df9ae348325a4f5775fd755aec8