### PR TITLE
Add vendor lookup and UI column

### DIFF
--- a/backend/src/roamingTracker.ts
+++ b/backend/src/roamingTracker.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { NodeData, RoamingEvent, LeaseInfo } from "./types";
+import { VendorLookup } from "./vendorLookup";
 
 interface ClientHistory {
   events: RoamingEvent[];
@@ -16,6 +17,7 @@ export class RoamingTracker {
   private arpTable: { [apName: string]: { [mac: string]: LeaseInfo } } = {};
   private hostMap: { [ip: string]: string };
   private saveHosts: (hosts: { [ip: string]: string }) => void;
+  private vendorLookup = new VendorLookup();
 
   constructor(
     macToName: { [mac: string]: string },
@@ -94,9 +96,12 @@ export class RoamingTracker {
           this.findInAll(this.arpTable, mac, "ip") || // fallback to IP
           "Unknown";
 
+        const vendor = this.vendorLookup.getVendor(mac);
+
         data.push({
           mac,
           name,
+          vendor,
           ip,
           currentAp: current.apName,
           fast: current.fastTransition,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -26,6 +26,7 @@ export interface RoamingEvent {
 export interface NodeData {
   mac: string;
   name: string;
+  vendor: string;
   ip: string;
   currentAp: string;
   fast: boolean;

--- a/backend/src/vendorLookup.ts
+++ b/backend/src/vendorLookup.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+
+export class VendorLookup {
+  private map24 = new Map<string, string>();
+  private map28 = new Map<string, string>();
+  private map36 = new Map<string, string>();
+  private loaded = false;
+
+  constructor(private dataDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../mac-vendors')) {
+    this.load();
+  }
+
+  private load() {
+    if (this.loaded) return;
+    this.loadFile('oui.csv', this.map24, 6);
+    this.loadFile('mam.csv', this.map28, 7);
+    this.loadFile('oui36.csv', this.map36, 9);
+    this.loaded = true;
+  }
+
+  private loadFile(fileName: string, map: Map<string, string>, len: number) {
+    const filePath = path.join(this.dataDir, fileName);
+    if (!fs.existsSync(filePath)) return;
+    let content = fs.readFileSync(filePath, 'utf-8');
+    if (content.startsWith('version https://git-lfs.github.com/spec')) {
+      return; // LFS placeholder, skip
+    }
+    const lines = content.split(/\r?\n/);
+    lines.shift(); // header
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const parts = line.split(',');
+      if (parts.length < 3) continue;
+      const assignment = parts[1].replace(/[^A-Fa-f0-9]/g, '').toUpperCase();
+      const vendor = parts[2].replace(/^"|"$/g, '').trim();
+      if (assignment) {
+        map.set(assignment.slice(0, len), vendor);
+      }
+    }
+  }
+
+  getVendor(mac: string): string {
+    const clean = mac.toUpperCase().replace(/[^A-F0-9]/g, '');
+    if (clean.length < 6) return 'Unknown';
+    const p36 = clean.slice(0, 9);
+    if (this.map36.has(p36)) return this.map36.get(p36)!;
+    const p28 = clean.slice(0, 7);
+    if (this.map28.has(p28)) return this.map28.get(p28)!;
+    const p24 = clean.slice(0, 6);
+    if (this.map24.has(p24)) return this.map24.get(p24)!;
+    return 'Unknown';
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,6 +62,7 @@
           <th>Client Name</th>
           <th>IP</th>
           <th>MAC</th>
+          <th>Vendor</th>
           <th>Current AP</th>
           <th>Fast</th>
           <th>Last Seen</th>
@@ -73,6 +74,7 @@
           <td @click="setName(client)">{{ client.name }}</td>
           <td>{{ client.ip }}</td>
           <td>{{ client.mac }}</td>
+          <td>{{ client.vendor }}</td>
           <td>{{ client.currentAp }}</td>
           <td :class="client.fast ? 'fast' : 'normal'">{{ client.fast ? 'Yes' : 'No' }}</td>
           <td>{{ formatLastSeen(client.diffSec) }}</td>


### PR DESCRIPTION
## Summary
- add new `VendorLookup` class for parsing vendor info from `backend/mac-vendors` csv files
- extend API output with `vendor` name in `NodeData`
- display the vendor in the frontend table

## Testing
- `npm install`
- `npm start` *(fails: ENOENT no such file or directory '/workspace/11r-monitor/backend/config.json')*

------
https://chatgpt.com/codex/tasks/task_e_6870cbb69a5483258ddaa3ef709e52ce